### PR TITLE
Set private methods protected to make class TucPki018Verifier more extendable

### DIFF
--- a/src/main/java/de/gematik/pki/certificate/TucPki018Verifier.java
+++ b/src/main/java/de/gematik/pki/certificate/TucPki018Verifier.java
@@ -41,19 +41,19 @@ import lombok.extern.slf4j.Slf4j;
  */
 
 @Slf4j
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class TucPki018Verifier {
 
     @NonNull
-    private final String productType;
+    protected final String productType;
     @NonNull
-    private final List<TspService> tspServiceList;
+    protected final List<TspService> tspServiceList;
     @NonNull
-    private final List<CertificateProfile> certificateProfiles;
+    protected final List<CertificateProfile> certificateProfiles;
     @Builder.Default
-    private final boolean withOcspCheck = true;
-    private final OcspRespCache ocspRespCache;
+    protected final boolean withOcspCheck = true;
+    protected final OcspRespCache ocspRespCache;
 
     /**
      * Verify given end-entity certificate against a list of parameterized certificate profiles {@link CertificateProfile}. If there is no {@link

--- a/src/main/java/de/gematik/pki/certificate/TucPki018Verifier.java
+++ b/src/main/java/de/gematik/pki/certificate/TucPki018Verifier.java
@@ -75,7 +75,7 @@ public class TucPki018Verifier {
         return tucPki018ProfileChecks(x509EeCert, tspServiceSubset);
     }
 
-    private Admission tucPki018ProfileChecks(@NonNull final X509Certificate x509EeCert, @NonNull final TspServiceSubset tspServiceSubset)
+    protected Admission tucPki018ProfileChecks(@NonNull final X509Certificate x509EeCert, @NonNull final TspServiceSubset tspServiceSubset)
         throws GemPkiException {
         if (certificateProfiles.isEmpty()) {
             throw new GemPkiException(productType, ErrorCode.UNKNOWN);
@@ -98,7 +98,7 @@ public class TucPki018Verifier {
         throw new GemPkiParsingException(productType, errors);
     }
 
-    private void doOcsp(@NonNull final X509Certificate x509EeCert, @NonNull final TspServiceSubset tspServiceSubset) throws GemPkiException {
+    protected void doOcsp(@NonNull final X509Certificate x509EeCert, @NonNull final TspServiceSubset tspServiceSubset) throws GemPkiException {
         final boolean ocspVerification = OcspTransceiver.builder()
             .x509EeCert(x509EeCert)
             .x509IssuerCert(tspServiceSubset.getX509IssuerCert())
@@ -121,7 +121,7 @@ public class TucPki018Verifier {
      * @param tspServiceSubset   the issuing certificates as trust store
      * @throws GemPkiException if the certificate is invalid
      */
-    private void tucPki018ChecksForProfile(@NonNull final X509Certificate x509EeCert, @NonNull final CertificateProfile certificateProfile,
+    protected void tucPki018ChecksForProfile(@NonNull final X509Certificate x509EeCert, @NonNull final CertificateProfile certificateProfile,
         @NonNull final TspServiceSubset tspServiceSubset) throws GemPkiException {
         final CertificateProfileVerification cv = CertificateProfileVerification.builder()
             .x509EeCert(x509EeCert)
@@ -135,7 +135,7 @@ public class TucPki018Verifier {
         cv.verifyCertificateType();
     }
 
-    private void tucPki018CommonChecks(@NonNull final X509Certificate x509EeCert, @NonNull final TspServiceSubset tspServiceSubset) throws GemPkiException {
+    protected void tucPki018CommonChecks(@NonNull final X509Certificate x509EeCert, @NonNull final TspServiceSubset tspServiceSubset) throws GemPkiException {
         final CertificateCommonVerification cv = CertificateCommonVerification.builder()
             .x509EeCert(x509EeCert)
             .tspServiceSubset(tspServiceSubset)


### PR DESCRIPTION
To make class TucPki018Verifier extendable in case of disabling some verification methods we make the methods protected.