### PR TITLE
Introduce validation interface to encapsulate validation steps

### DIFF
--- a/src/main/java/de/gematik/pki/gemlibpki/certificate/CertificateProfileVerification.java
+++ b/src/main/java/de/gematik/pki/gemlibpki/certificate/CertificateProfileVerification.java
@@ -16,26 +16,16 @@
 
 package de.gematik.pki.gemlibpki.certificate;
 
-import static de.gematik.pki.gemlibpki.certificate.CertificateProfile.CERT_PROFILE_C_TSL_SIG;
-
-import de.gematik.pki.gemlibpki.error.ErrorCode;
 import de.gematik.pki.gemlibpki.exception.GemPkiException;
-import de.gematik.pki.gemlibpki.exception.GemPkiRuntimeException;
 import de.gematik.pki.gemlibpki.tsl.TspServiceSubset;
-import eu.europa.esig.trustedlist.jaxb.tsl.ExtensionType;
-import java.io.IOException;
-import java.security.cert.CertificateParsingException;
-import java.security.cert.X509Certificate;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+import de.gematik.pki.gemlibpki.validators.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.bouncycastle.asn1.x509.Extension;
-import org.w3c.dom.Node;
+
+import java.security.cert.X509Certificate;
 
 /**
  * Class for verification checks on a certificate against a profile. This class works with
@@ -47,248 +37,30 @@ import org.w3c.dom.Node;
 @Builder
 public final class CertificateProfileVerification {
 
-  @NonNull private final String productType;
-  @NonNull private final TspServiceSubset tspServiceSubset;
-  @NonNull private final CertificateProfile certificateProfile;
-  @NonNull private final X509Certificate x509EeCert;
+    @NonNull
+    private final String productType;
+    @NonNull
+    private final TspServiceSubset tspServiceSubset;
+    @NonNull
+    private final CertificateProfile certificateProfile;
+    @NonNull
+    private final X509Certificate x509EeCert;
 
-  // ####################  Start KeyUsage ########################################################
+    /**
+     * Perform all verification checks
+     *
+     * @throws GemPkiException thrown if cert cannot be verified according to KeyUsage, ExtKeyUsage or
+     *                         CertType
+     */
+    public void verifyAll() throws GemPkiException {
 
-  /**
-   * Perform all verification checks
-   *
-   * @throws GemPkiException thrown if cert cannot be verified according to KeyUsage, ExtKeyUsage or
-   *     CertType
-   */
-  public void verifyAll() throws GemPkiException {
-    verifyKeyUsage();
-    verifyExtendedKeyUsage();
-    verifyCertificateType();
-    verifyCriticalExtensions();
-  }
+        new KeyUsageValidator(productType).validateCertificate(x509EeCert, certificateProfile);
+        new ExtendedKeyUsageValidator(productType).validateCertificate(x509EeCert, certificateProfile);
 
-  /**
-   * Verify that all intended KeyUsage bit(s) of certificate profile {@link CertificateProfile}
-   * match against KeyUsage(s) of parameterized end-entity certificate and that the KeyUsages
-   * extension in the certificate is present
-   *
-   * @throws GemPkiException if the certificate has a wrong key usage
-   */
-  public void verifyKeyUsage() throws GemPkiException {
-    final boolean[] certKeyUsage = x509EeCert.getKeyUsage();
-    if (certKeyUsage == null) {
-      log.error("KeyUsage extension im Zertifikat nicht vorhanden.");
-      throw new GemPkiException(productType, ErrorCode.SE_1016_WRONG_KEYUSAGE);
+        new CertificateProfileByCertificateTypeOidValidator(productType).validateCertificate(x509EeCert, certificateProfile);
+        new CertificateTypeOidInIssuerTspServiceExtensionValidator(productType, tspServiceSubset).validateCertificate(x509EeCert, certificateProfile);
+
+        new CriticalExtensionsValidator(productType).validateCertificate(x509EeCert, certificateProfile);
     }
 
-    final List<KeyUsage> intendedKeyUsageList =
-        getIntendedKeyUsagesFromCertificateProfile(certificateProfile);
-    if (intendedKeyUsageList.isEmpty()) {
-      log.info(
-          "Skipping check of KeyUsage, because of user request. CertProfile used: {}",
-          certificateProfile.name());
-      return;
-    }
-
-    int nrBitsEe = 0;
-
-    for (final boolean bit : certKeyUsage) {
-      if (bit) {
-        nrBitsEe++;
-      }
-    }
-    if (nrBitsEe != intendedKeyUsageList.size()) {
-      throw new GemPkiException(productType, ErrorCode.SE_1016_WRONG_KEYUSAGE);
-    }
-    for (final KeyUsage keyUsage : intendedKeyUsageList) {
-      if (!certKeyUsage[keyUsage.getBit()]) {
-        throw new GemPkiException(productType, ErrorCode.SE_1016_WRONG_KEYUSAGE);
-      }
-    }
-  }
-
-  /**
-   * Get list of KeyUsage(s) to the parameterized certificate profile {@link CertificateProfile}.
-   *
-   * @param certificateProfile The certificate profile
-   * @return List with keyUsage(s)
-   */
-  private static List<KeyUsage> getIntendedKeyUsagesFromCertificateProfile(
-      final CertificateProfile certificateProfile) {
-    return CertificateProfile.valueOf(certificateProfile.name()).getKeyUsages();
-  }
-
-  // ####################  End KeyUsage ########################################################
-  // ####################  Start ExtendedKeyUsage ##############################################
-
-  /**
-   * Verify oid of intended ExtendedKeyUsage(s) from certificate profile {@link CertificateProfile}
-   * must match with oid(s) from a parameterized end-entity certificate with respect to cardinality.
-   *
-   * @throws GemPkiException if certificate has a wrong key usage
-   */
-  public void verifyExtendedKeyUsage() throws GemPkiException {
-
-    final List<String> intendedExtendedKeyUsageOidList =
-        getOidOfIntendedExtendedKeyUsagesFromCertificateProfile(certificateProfile);
-
-    if (intendedExtendedKeyUsageOidList.isEmpty() || !certificateProfile.isFailOnMissingEku()) {
-      log.info(
-          "Skipping check of extendedKeyUsage, because of user request. CertProfile used: {}",
-          certificateProfile.name());
-      return;
-    }
-
-    final List<String> eeExtendedKeyUsagesOid;
-    try {
-      eeExtendedKeyUsagesOid = x509EeCert.getExtendedKeyUsage();
-    } catch (final CertificateParsingException e) {
-      throw new GemPkiRuntimeException(
-          "Fehler beim Lesen der ExtendedKeyUsages des Zertifikats: "
-              + x509EeCert.getSubjectX500Principal().getName(),
-          e);
-    }
-
-    if (eeExtendedKeyUsagesOid == null) {
-      throw new GemPkiException(productType, ErrorCode.SE_1017_WRONG_EXTENDEDKEYUSAGE);
-    }
-    final List<String> filteredList =
-        eeExtendedKeyUsagesOid.stream()
-            .filter(
-                eeOid ->
-                    intendedExtendedKeyUsageOidList.stream()
-                        .anyMatch(intOid -> intOid.equals(eeOid)))
-            .toList();
-    if (filteredList.isEmpty()
-        || (eeExtendedKeyUsagesOid.size() != intendedExtendedKeyUsageOidList.size())) {
-      log.debug("{}", ErrorCode.SE_1017_WRONG_EXTENDEDKEYUSAGE.getErrorMessage(productType));
-      throw new GemPkiException(productType, ErrorCode.SE_1017_WRONG_EXTENDEDKEYUSAGE);
-    }
-  }
-
-  /**
-   * Get list of oid(s) of ExtendedKeyUsage(s) to the parameterized profile.
-   *
-   * @param certificateProfile The certificate profile
-   * @return List of oid(s) of ExtendedKeyUsages from certificate profile {@link CertificateProfile}
-   */
-  private static List<String> getOidOfIntendedExtendedKeyUsagesFromCertificateProfile(
-      final CertificateProfile certificateProfile) {
-    return CertificateProfile.valueOf(certificateProfile.name()).getExtKeyUsages().stream()
-        .map(ExtendedKeyUsage::getOid)
-        .toList();
-  }
-
-  // ####################  End ExtendedKeyUsage #####################
-  // ############## Start certificate type checks ###################
-
-  /**
-   * Verify type of parameterized end-entity certificate against parameterized certificate profile
-   * {@link CertificateProfile}.
-   *
-   * @throws GemPkiException if certificate type verification fails
-   */
-  public void verifyCertificateType() throws GemPkiException {
-    if (!certificateProfile.equals(CERT_PROFILE_C_TSL_SIG)) {
-      final Set<String> certificatePolicyOids = getCertificatePolicyOids(x509EeCert);
-      verifyCertificateProfileByCertificateTypeOid(certificatePolicyOids);
-      verifyCertificateTypeOidInIssuerTspServiceExtension(certificatePolicyOids);
-    }
-  }
-
-  /** AFO GS-A_4661-01 (RFC5280#4.2) */
-  public void verifyCriticalExtensions() throws GemPkiException {
-    final Set<String> certCriticalExtensions = x509EeCert.getCriticalExtensionOIDs();
-
-    // NOTE: as specified in gemSpec_PKI 2.15.0 for all certificate profiles in Kapitel 5
-    // X.509-Zertifikate
-
-    final Set<String> expectedCriticalExtensions =
-        Set.of(Extension.basicConstraints.getId(), Extension.keyUsage.getId());
-
-    if (!expectedCriticalExtensions.equals(certCriticalExtensions)) {
-      log.error(
-          "Detected unknown / missing critical extensions in certificate {} vs expected {}",
-          new TreeSet<>(certCriticalExtensions),
-          new TreeSet<>(expectedCriticalExtensions));
-      throw new GemPkiException(productType, ErrorCode.CUSTOM_CERTIFICATE_EXCEPTION);
-    }
-  }
-
-  /**
-   * Check given list of certificate policy type oid(s) contains type oid from parameterized
-   * certificate profile {@link CertificateProfile}.
-   *
-   * @param certificatePolicyOidList list with policy oid(s)
-   * @throws GemPkiException if the certificate has a wong cert type
-   */
-  private void verifyCertificateProfileByCertificateTypeOid(
-      final Set<String> certificatePolicyOidList) throws GemPkiException {
-
-    if (certificateProfile.getCertificateType().equals(CertificateType.CERT_TYPE_ANY)) {
-      log.info(
-          "Skipping check of CertificateTypeOid, because of user request. CertProfile used: {}",
-          certificateProfile.name());
-      return;
-    }
-
-    if (!certificatePolicyOidList.contains(certificateProfile.getCertificateType().getOid())) {
-      log.debug("ZertifikatsTypOids im Zertifikat: {}", certificatePolicyOidList);
-      log.debug(
-          "Erwartete ZertifikatsTypOid: {}", certificateProfile.getCertificateType().getOid());
-      throw new GemPkiException(productType, ErrorCode.SE_1018_CERT_TYPE_MISMATCH);
-    }
-  }
-
-  /**
-   * Verify that list of extension oid(s) from issuer TspService contains at least one oid of given
-   * certificate type oid list.
-   *
-   * @param certificateTypeOidList a list with certificate type oid(s)
-   * @throws GemPkiException if the certificate issuer is not allowed to issue this cert type
-   */
-  private void verifyCertificateTypeOidInIssuerTspServiceExtension(
-      final Set<String> certificateTypeOidList) throws GemPkiException {
-    log.debug(
-        "Prüfe CA Autorisierung für die Herausgabe des Zertifikatstyps {} ",
-        certificateProfile.getCertificateType().getOidReference());
-    for (final ExtensionType extensionType : tspServiceSubset.getExtensions()) {
-      final List<Object> content = extensionType.getContent();
-      for (final Object object : content) {
-        if (object instanceof final Node node) {
-          final Node firstChild = node.getFirstChild();
-          if (certificateTypeOidList.contains(firstChild.getNodeValue().trim())) {
-            return;
-          }
-        }
-      }
-    }
-    throw new GemPkiException(productType, ErrorCode.SE_1061_CERT_TYPE_CA_NOT_AUTHORIZED);
-  }
-
-  /**
-   * Get policy oids to given end-entity certificate. 1.Test: exists policy extension oid identifier
-   * at all (implizit over IllegalArgumentException). 2.Test: extract value from policy extension
-   * oid.
-   *
-   * @param x509EeCert end-entity certificate
-   * @return Set<String> policy oids from end-entity certificate
-   * @throws GemPkiException if the certificate has no cert type
-   */
-  private Set<String> getCertificatePolicyOids(final X509Certificate x509EeCert)
-      throws GemPkiException {
-    try {
-      final Policies policies = new Policies(x509EeCert);
-      if (policies.getPolicyOids().isEmpty()) {
-        throw new GemPkiException(productType, ErrorCode.SE_1033_CERT_TYPE_INFO_MISSING);
-      }
-      return policies.getPolicyOids();
-    } catch (final IllegalArgumentException e) {
-      throw new GemPkiException(productType, ErrorCode.SE_1033_CERT_TYPE_INFO_MISSING);
-    } catch (final IOException e) {
-      throw new GemPkiException(productType, ErrorCode.TE_1019_CERT_READ_ERROR);
-    }
-  }
-  // ############## End certificate type checks
-  // #######################################################
 }

--- a/src/main/java/de/gematik/pki/gemlibpki/ocsp/OcspTransceiver.java
+++ b/src/main/java/de/gematik/pki/gemlibpki/ocsp/OcspTransceiver.java
@@ -65,7 +65,7 @@ public final class OcspTransceiver {
 
   @Builder.Default private final boolean tolerateOcspFailure = false;
 
-  private TucPki006OcspVerifier getTucPki006Verifier(final OCSPResp ocspResp) {
+  public TucPki006OcspVerifier getTucPki006Verifier(final OCSPResp ocspResp) {
 
     return TucPki006OcspVerifier.builder()
         .productType(productType)

--- a/src/main/java/de/gematik/pki/gemlibpki/tsl/TucPki001Verifier.java
+++ b/src/main/java/de/gematik/pki/gemlibpki/tsl/TucPki001Verifier.java
@@ -29,6 +29,7 @@ import de.gematik.pki.gemlibpki.ocsp.OcspConstants;
 import de.gematik.pki.gemlibpki.ocsp.OcspRespCache;
 import de.gematik.pki.gemlibpki.utils.CertReader;
 import de.gematik.pki.gemlibpki.utils.GemLibPkiUtils;
+import de.gematik.pki.gemlibpki.validators.ValidityValidator;
 import eu.europa.esig.trustedlist.jaxb.tsl.TSPServiceType;
 import eu.europa.esig.trustedlist.jaxb.tsl.TrustStatusListType;
 import java.io.IOException;
@@ -295,15 +296,7 @@ public class TucPki001Verifier {
       final X509Certificate futureTrustAnchor =
           CertReader.readX509(productType, futureTrustAnchorBytes);
 
-      final TspServiceSubset tspServiceTrustAnchorSubset =
-          TspServiceSubset.builder().x509IssuerCert(futureTrustAnchor).build();
-
-      CertificateCommonVerification.builder()
-          .productType(productType)
-          .x509EeCert(futureTrustAnchor)
-          .tspServiceSubset(tspServiceTrustAnchorSubset)
-          .build()
-          .verifyValidity(referenceDate);
+      new ValidityValidator(productType).validateCertificate(futureTrustAnchor, referenceDate);
 
       log.debug(
           "verification of the trust anchor successful: certSerialNr {}, statusStartingTime {}",

--- a/src/main/java/de/gematik/pki/gemlibpki/validators/CertificateProfileByCertificateTypeOidValidator.java
+++ b/src/main/java/de/gematik/pki/gemlibpki/validators/CertificateProfileByCertificateTypeOidValidator.java
@@ -1,0 +1,76 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.certificate.CertificateProfile;
+import de.gematik.pki.gemlibpki.certificate.CertificateType;
+import de.gematik.pki.gemlibpki.certificate.Policies;
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.security.cert.X509Certificate;
+import java.util.Set;
+
+import static de.gematik.pki.gemlibpki.certificate.CertificateProfile.CERT_PROFILE_C_TSL_SIG;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CertificateProfileByCertificateTypeOidValidator implements CertificateProfileValidator {
+
+    @NonNull
+    private final String productType;
+
+    /**
+     * Check given list of certificate policy type oid(s) contains type oid from parameterized
+     * certificate profile {@link CertificateProfile}.
+     *
+     * @throws GemPkiException if the certificate has a wong cert type
+     */
+    @Override
+    public void validateCertificate(@NonNull X509Certificate x509EeCert, @NonNull CertificateProfile certificateProfile) throws GemPkiException {
+        if (certificateProfile.equals(CERT_PROFILE_C_TSL_SIG)) {
+            return;
+        }
+        final Set<String> certificatePolicyOidList = getCertificatePolicyOids(x509EeCert);
+
+        if (certificateProfile.getCertificateType().equals(CertificateType.CERT_TYPE_ANY)) {
+            log.info(
+                    "Skipping check of CertificateTypeOid, because of user request. CertProfile used: {}",
+                    certificateProfile.name());
+            return;
+        }
+
+        if (!certificatePolicyOidList.contains(certificateProfile.getCertificateType().getOid())) {
+            log.debug("ZertifikatsTypOids im Zertifikat: {}", certificatePolicyOidList);
+            log.debug(
+                    "Erwartete ZertifikatsTypOid: {}", certificateProfile.getCertificateType().getOid());
+            throw new GemPkiException(productType, ErrorCode.SE_1018_CERT_TYPE_MISMATCH);
+        }
+    }
+
+    /**
+     * Get policy oids to given end-entity certificate. 1.Test: exists policy extension oid identifier
+     * at all (implizit over IllegalArgumentException). 2.Test: extract value from policy extension
+     * oid.
+     *
+     * @param x509EeCert end-entity certificate
+     * @return Set<String> policy oids from end-entity certificate
+     * @throws GemPkiException if the certificate has no cert type
+     */
+    private Set<String> getCertificatePolicyOids(final X509Certificate x509EeCert)
+            throws GemPkiException {
+        try {
+            final Policies policies = new Policies(x509EeCert);
+            if (policies.getPolicyOids().isEmpty()) {
+                throw new GemPkiException(productType, ErrorCode.SE_1033_CERT_TYPE_INFO_MISSING);
+            }
+            return policies.getPolicyOids();
+        } catch (final IllegalArgumentException e) {
+            throw new GemPkiException(productType, ErrorCode.SE_1033_CERT_TYPE_INFO_MISSING);
+        } catch (final IOException e) {
+            throw new GemPkiException(productType, ErrorCode.TE_1019_CERT_READ_ERROR);
+        }
+    }
+}

--- a/src/main/java/de/gematik/pki/gemlibpki/validators/CertificateProfileValidator.java
+++ b/src/main/java/de/gematik/pki/gemlibpki/validators/CertificateProfileValidator.java
@@ -1,0 +1,14 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.certificate.CertificateProfile;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import lombok.NonNull;
+
+import java.security.cert.X509Certificate;
+
+public interface CertificateProfileValidator {
+
+    void validateCertificate(@NonNull X509Certificate x509EeCert, @NonNull CertificateProfile certificateProfile)
+            throws GemPkiException;
+
+}

--- a/src/main/java/de/gematik/pki/gemlibpki/validators/CertificateTypeOidInIssuerTspServiceExtensionValidator.java
+++ b/src/main/java/de/gematik/pki/gemlibpki/validators/CertificateTypeOidInIssuerTspServiceExtensionValidator.java
@@ -1,0 +1,84 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.certificate.CertificateProfile;
+import de.gematik.pki.gemlibpki.certificate.Policies;
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import de.gematik.pki.gemlibpki.tsl.TspServiceSubset;
+import eu.europa.esig.trustedlist.jaxb.tsl.ExtensionType;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.w3c.dom.Node;
+
+import java.io.IOException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Set;
+
+import static de.gematik.pki.gemlibpki.certificate.CertificateProfile.CERT_PROFILE_C_TSL_SIG;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CertificateTypeOidInIssuerTspServiceExtensionValidator implements CertificateProfileValidator {
+
+    @NonNull
+    private final String productType;
+    @NonNull
+    private final TspServiceSubset tspServiceSubset;
+
+    /**
+     * Verify that list of extension oid(s) from issuer TspService contains at least one oid of given
+     * certificate type oid list.
+     *
+     * @throws GemPkiException if the certificate issuer is not allowed to issue this cert type
+     */
+    @Override
+    public void validateCertificate(@NonNull X509Certificate x509EeCert, @NonNull CertificateProfile certificateProfile) throws GemPkiException {
+        if (certificateProfile.equals(CERT_PROFILE_C_TSL_SIG)) {
+            return;
+        }
+        final Set<String> certificateTypeOidList = getCertificatePolicyOids(x509EeCert);
+
+        log.debug(
+                "Prüfe CA Autorisierung für die Herausgabe des Zertifikatstyps {} ",
+                certificateProfile.getCertificateType().getOidReference());
+        for (final ExtensionType extensionType : tspServiceSubset.getExtensions()) {
+            final List<Object> content = extensionType.getContent();
+            for (final Object object : content) {
+                if (object instanceof final Node node) {
+                    final Node firstChild = node.getFirstChild();
+                    if (certificateTypeOidList.contains(firstChild.getNodeValue().trim())) {
+                        return;
+                    }
+                }
+            }
+        }
+        throw new GemPkiException(productType, ErrorCode.SE_1061_CERT_TYPE_CA_NOT_AUTHORIZED);
+    }
+
+    /**
+     * Get policy oids to given end-entity certificate. 1.Test: exists policy extension oid identifier
+     * at all (implizit over IllegalArgumentException). 2.Test: extract value from policy extension
+     * oid.
+     *
+     * @param x509EeCert end-entity certificate
+     * @return Set<String> policy oids from end-entity certificate
+     * @throws GemPkiException if the certificate has no cert type
+     */
+    private Set<String> getCertificatePolicyOids(final X509Certificate x509EeCert)
+            throws GemPkiException {
+        try {
+            final Policies policies = new Policies(x509EeCert);
+            if (policies.getPolicyOids().isEmpty()) {
+                throw new GemPkiException(productType, ErrorCode.SE_1033_CERT_TYPE_INFO_MISSING);
+            }
+            return policies.getPolicyOids();
+        } catch (final IllegalArgumentException e) {
+            throw new GemPkiException(productType, ErrorCode.SE_1033_CERT_TYPE_INFO_MISSING);
+        } catch (final IOException e) {
+            throw new GemPkiException(productType, ErrorCode.TE_1019_CERT_READ_ERROR);
+        }
+    }
+
+}

--- a/src/main/java/de/gematik/pki/gemlibpki/validators/CertificateValidator.java
+++ b/src/main/java/de/gematik/pki/gemlibpki/validators/CertificateValidator.java
@@ -1,0 +1,30 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+import java.security.cert.X509Certificate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public interface CertificateValidator {
+
+    default void validateCertificate(@NonNull X509Certificate x509EeCert) throws GemPkiException {
+        validateCertificate(x509EeCert, ZonedDateTime.now(ZoneOffset.UTC), new ValidationContext());
+    }
+
+    default void validateCertificate(@NonNull X509Certificate x509EeCert, @NonNull ZonedDateTime referenceDate) throws GemPkiException {
+        validateCertificate(x509EeCert, referenceDate, new ValidationContext());
+    }
+
+    void validateCertificate(@NonNull X509Certificate x509EeCert, @NonNull ZonedDateTime referenceDate, @NonNull ValidationContext context)
+            throws GemPkiException;
+
+    @Getter
+    @Setter
+    class ValidationContext {
+        String ocspAddress;
+    }
+}

--- a/src/main/java/de/gematik/pki/gemlibpki/validators/CriticalExtensionsValidator.java
+++ b/src/main/java/de/gematik/pki/gemlibpki/validators/CriticalExtensionsValidator.java
@@ -1,0 +1,44 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.certificate.CertificateProfile;
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.asn1.x509.Extension;
+
+import java.security.cert.X509Certificate;
+import java.util.Set;
+import java.util.TreeSet;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CriticalExtensionsValidator implements CertificateProfileValidator {
+
+    @NonNull
+    private final String productType;
+
+    /**
+     * AFO GS-A_4661-01 (RFC5280#4.2)
+     */
+    @Override
+    public void validateCertificate(@NonNull X509Certificate x509EeCert, @NonNull CertificateProfile certificateProfile) throws GemPkiException {
+
+        final Set<String> certCriticalExtensions = x509EeCert.getCriticalExtensionOIDs();
+
+        // NOTE: as specified in gemSpec_PKI 2.15.0 for all certificate profiles in Kapitel 5
+        // X.509-Zertifikate
+
+        final Set<String> expectedCriticalExtensions =
+                Set.of(Extension.basicConstraints.getId(), Extension.keyUsage.getId());
+
+        if (!expectedCriticalExtensions.equals(certCriticalExtensions)) {
+            log.error(
+                    "Detected unknown / missing critical extensions in certificate {} vs expected {}",
+                    new TreeSet<>(certCriticalExtensions),
+                    new TreeSet<>(expectedCriticalExtensions));
+            throw new GemPkiException(productType, ErrorCode.CUSTOM_CERTIFICATE_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/de/gematik/pki/gemlibpki/validators/ExtendedKeyUsageValidator.java
+++ b/src/main/java/de/gematik/pki/gemlibpki/validators/ExtendedKeyUsageValidator.java
@@ -1,0 +1,83 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.certificate.CertificateProfile;
+import de.gematik.pki.gemlibpki.certificate.ExtendedKeyUsage;
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import de.gematik.pki.gemlibpki.exception.GemPkiRuntimeException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ExtendedKeyUsageValidator implements CertificateProfileValidator {
+
+    @NonNull
+    private final String productType;
+
+    /**
+     * Verify oid of intended ExtendedKeyUsage(s) from certificate profile {@link CertificateProfile}
+     * must match with oid(s) from a parameterized end-entity certificate with respect to cardinality.
+     *
+     * @throws GemPkiException if certificate has a wrong key usage
+     */
+    @Override
+    public void validateCertificate(@NonNull X509Certificate x509EeCert, @NonNull CertificateProfile certificateProfile) throws GemPkiException {
+
+        final List<String> intendedExtendedKeyUsageOidList =
+                getOidOfIntendedExtendedKeyUsagesFromCertificateProfile(certificateProfile);
+
+        if (intendedExtendedKeyUsageOidList.isEmpty() || !certificateProfile.isFailOnMissingEku()) {
+            log.info(
+                    "Skipping check of extendedKeyUsage, because of user request. CertProfile used: {}",
+                    certificateProfile.name());
+            return;
+        }
+
+        final List<String> eeExtendedKeyUsagesOid;
+        try {
+            eeExtendedKeyUsagesOid = x509EeCert.getExtendedKeyUsage();
+        } catch (final CertificateParsingException e) {
+            throw new GemPkiRuntimeException(
+                    "Fehler beim Lesen der ExtendedKeyUsages des Zertifikats: "
+                            + x509EeCert.getSubjectX500Principal().getName(),
+                    e);
+        }
+
+        if (eeExtendedKeyUsagesOid == null) {
+            throw new GemPkiException(productType, ErrorCode.SE_1017_WRONG_EXTENDEDKEYUSAGE);
+        }
+        final List<String> filteredList =
+                eeExtendedKeyUsagesOid.stream()
+                        .filter(
+                                eeOid ->
+                                        intendedExtendedKeyUsageOidList.stream()
+                                                .anyMatch(intOid -> intOid.equals(eeOid)))
+                        .toList();
+        if (filteredList.isEmpty()
+                || (eeExtendedKeyUsagesOid.size() != intendedExtendedKeyUsageOidList.size())) {
+            log.debug("{}", ErrorCode.SE_1017_WRONG_EXTENDEDKEYUSAGE.getErrorMessage(productType));
+            throw new GemPkiException(productType, ErrorCode.SE_1017_WRONG_EXTENDEDKEYUSAGE);
+        }
+    }
+
+    /**
+     * Get list of oid(s) of ExtendedKeyUsage(s) to the parameterized profile.
+     *
+     * @param certificateProfile The certificate profile
+     * @return List of oid(s) of ExtendedKeyUsages from certificate profile {@link CertificateProfile}
+     */
+    private static List<String> getOidOfIntendedExtendedKeyUsagesFromCertificateProfile(
+            final CertificateProfile certificateProfile) {
+        return CertificateProfile.valueOf(certificateProfile.name()).getExtKeyUsages().stream()
+                .map(ExtendedKeyUsage::getOid)
+                .toList();
+    }
+
+
+}

--- a/src/main/java/de/gematik/pki/gemlibpki/validators/IssuerServiceStatusValidator.java
+++ b/src/main/java/de/gematik/pki/gemlibpki/validators/IssuerServiceStatusValidator.java
@@ -1,0 +1,44 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import de.gematik.pki.gemlibpki.tsl.TslConstants;
+import de.gematik.pki.gemlibpki.tsl.TspServiceSubset;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.cert.X509Certificate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+public class IssuerServiceStatusValidator implements CertificateValidator {
+
+    @NonNull
+    private final String productType;
+    @NonNull
+    private final TspServiceSubset tspServiceSubset;
+
+    /**
+     * Verify issuer service status from tsl file. The status determines if an end-entity certificate
+     * was issued after the CA (Issuer) was revoked.
+     *
+     * @throws GemPkiException if certificate has been revoked
+     */
+    @Override
+    public void validateCertificate(@NonNull X509Certificate x509EeCert, @NonNull  ZonedDateTime referenceDate, @NonNull ValidationContext context) throws GemPkiException {
+
+        if (!tspServiceSubset.getServiceStatus().equals(TslConstants.SVCSTATUS_REVOKED)) {
+            return;
+        }
+
+        final ZonedDateTime statusStartingTime = tspServiceSubset.getStatusStartingTime();
+        final ZonedDateTime notBefore = x509EeCert.getNotBefore().toInstant().atZone(ZoneOffset.UTC);
+
+        if (statusStartingTime.isBefore(notBefore)) {
+            throw new GemPkiException(productType, ErrorCode.SE_1036_CA_CERTIFICATE_REVOKED_IN_TSL);
+        }
+    }
+}

--- a/src/main/java/de/gematik/pki/gemlibpki/validators/KeyUsageValidator.java
+++ b/src/main/java/de/gematik/pki/gemlibpki/validators/KeyUsageValidator.java
@@ -1,0 +1,73 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.certificate.CertificateProfile;
+import de.gematik.pki.gemlibpki.certificate.KeyUsage;
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class KeyUsageValidator implements CertificateProfileValidator {
+
+    @NonNull
+    private final String productType;
+
+    /**
+     * Verify that all intended KeyUsage bit(s) of certificate profile {@link CertificateProfile}
+     * match against KeyUsage(s) of parameterized end-entity certificate and that the KeyUsages
+     * extension in the certificate is present
+     *
+     * @throws GemPkiException if the certificate has a wrong key usage
+     */
+    @Override
+    public void validateCertificate(@NonNull X509Certificate x509EeCert, @NonNull CertificateProfile certificateProfile) throws GemPkiException {
+
+        final boolean[] certKeyUsage = x509EeCert.getKeyUsage();
+        if (certKeyUsage == null) {
+            log.error("KeyUsage extension im Zertifikat nicht vorhanden.");
+            throw new GemPkiException(productType, ErrorCode.SE_1016_WRONG_KEYUSAGE);
+        }
+
+        final List<KeyUsage> intendedKeyUsageList =
+                getIntendedKeyUsagesFromCertificateProfile(certificateProfile);
+        if (intendedKeyUsageList.isEmpty()) {
+            log.info(
+                    "Skipping check of KeyUsage, because of user request. CertProfile used: {}",
+                    certificateProfile.name());
+            return;
+        }
+
+        int nrBitsEe = 0;
+
+        for (final boolean bit : certKeyUsage) {
+            if (bit) {
+                nrBitsEe++;
+            }
+        }
+        if (nrBitsEe != intendedKeyUsageList.size()) {
+            throw new GemPkiException(productType, ErrorCode.SE_1016_WRONG_KEYUSAGE);
+        }
+        for (final KeyUsage keyUsage : intendedKeyUsageList) {
+            if (!certKeyUsage[keyUsage.getBit()]) {
+                throw new GemPkiException(productType, ErrorCode.SE_1016_WRONG_KEYUSAGE);
+            }
+        }
+    }
+
+    /**
+     * Get list of KeyUsage(s) to the parameterized certificate profile {@link CertificateProfile}.
+     *
+     * @param certificateProfile The certificate profile
+     * @return List with keyUsage(s)
+     */
+    private static List<KeyUsage> getIntendedKeyUsagesFromCertificateProfile(
+            final CertificateProfile certificateProfile) {
+        return CertificateProfile.valueOf(certificateProfile.name()).getKeyUsages();
+    }
+}

--- a/src/main/java/de/gematik/pki/gemlibpki/validators/OCSPValidator.java
+++ b/src/main/java/de/gematik/pki/gemlibpki/validators/OCSPValidator.java
@@ -1,0 +1,78 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import de.gematik.pki.gemlibpki.ocsp.OcspRespCache;
+import de.gematik.pki.gemlibpki.ocsp.OcspTransceiver;
+import de.gematik.pki.gemlibpki.ocsp.TucPki006OcspVerifier;
+import de.gematik.pki.gemlibpki.tsl.TspInformationProvider;
+import de.gematik.pki.gemlibpki.tsl.TspService;
+import de.gematik.pki.gemlibpki.tsl.TspServiceSubset;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.cert.ocsp.OCSPResp;
+
+import java.security.cert.X509Certificate;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OCSPValidator implements CertificateValidator {
+
+    @NonNull
+    private final String productType;
+    @NonNull
+    private final List<TspService> tspServiceList;
+
+    private final boolean withOcspCheck;
+    private final OCSPResp ocspResponse;
+    private final OcspRespCache ocspRespCache;
+    private final int ocspTimeoutSeconds;
+    private final boolean tolerateOcspFailure;
+
+
+    /**
+     * Verify signature of parameterized end-entity certificate against given issuer certificate.
+     * Issuer certificate (CA) is determined from TSL file.
+     *
+     * @throws GemPkiException if certificate is mathematically invalid
+     */
+    @Override
+    public void validateCertificate(@NonNull X509Certificate x509EeCert, @NonNull ZonedDateTime referenceDate, @NonNull ValidationContext context) throws GemPkiException {
+        if (!withOcspCheck) {
+            log.warn(ErrorCode.SW_1039_NO_OCSP_CHECK.getErrorMessage(productType));
+            return;
+        }
+
+        final TspServiceSubset tspServiceSubset = new TspInformationProvider(tspServiceList, productType).getIssuerTspServiceSubset(x509EeCert);
+
+        final X509Certificate x509IssuerCert = tspServiceSubset.getX509IssuerCert();
+
+        final OcspTransceiver transceiver =
+                OcspTransceiver.builder()
+                        .productType(productType)
+                        .tspServiceList(tspServiceList)
+                        .x509EeCert(x509EeCert)
+                        .x509IssuerCert(x509IssuerCert)
+                        .ssp(tspServiceSubset.getServiceSupplyPoint())
+                        .ocspTimeoutSeconds(ocspTimeoutSeconds)
+                        .tolerateOcspFailure(tolerateOcspFailure)
+                        .build();
+
+        if (ocspResponse != null) {
+            try {
+                final TucPki006OcspVerifier verifier = transceiver.getTucPki006Verifier(ocspResponse);
+                verifier.performTucPki006Checks(referenceDate);
+                return;
+
+            } catch (final GemPkiException e) {
+                log.warn(ErrorCode.TW_1050_PROVIDED_OCSP_RESPONSE_NOT_VALID.getErrorMessage(productType));
+            }
+        }
+        context.setOcspAddress(tspServiceSubset.getServiceSupplyPoint());
+
+        transceiver.verifyOcspResponse(ocspRespCache, referenceDate);
+    }
+}

--- a/src/main/java/de/gematik/pki/gemlibpki/validators/SignatureValidator.java
+++ b/src/main/java/de/gematik/pki/gemlibpki/validators/SignatureValidator.java
@@ -1,0 +1,40 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.GeneralSecurityException;
+import java.security.cert.X509Certificate;
+import java.time.ZonedDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SignatureValidator implements CertificateValidator {
+
+    @NonNull
+    private final String productType;
+    @NonNull
+    private final X509Certificate x509IssuerCert;
+
+
+    /**
+     * Verify signature of parameterized end-entity certificate against given issuer certificate.
+     * Issuer certificate (CA) is determined from TSL file.
+     *
+     * @throws GemPkiException if certificate is mathematically invalid
+     */
+    @Override
+    public void validateCertificate(@NonNull X509Certificate x509EeCert, @NonNull ZonedDateTime referenceDate, @NonNull ValidationContext context) throws GemPkiException {
+
+        try {
+            x509EeCert.verify(x509IssuerCert.getPublicKey());
+            log.debug("Signature verification for end entity certificate successful.");
+        } catch (final GeneralSecurityException verifyFailed) {
+            throw new GemPkiException(
+                    productType, ErrorCode.SE_1024_CERTIFICATE_NOT_VALID_MATH, verifyFailed);
+        }
+    }
+}

--- a/src/main/java/de/gematik/pki/gemlibpki/validators/ValidityValidator.java
+++ b/src/main/java/de/gematik/pki/gemlibpki/validators/ValidityValidator.java
@@ -1,0 +1,49 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.cert.X509Certificate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ValidityValidator implements CertificateValidator {
+
+    @NonNull
+    private final String productType;
+
+    /**
+     * Verify validity period of parameterized end-entity certificate against a given reference date.
+     * TUC_PKI_002 „Gültigkeitsprüfung des Zertifikats“
+     *
+     * @param referenceDate date to check against
+     * @throws GemPkiException if certificate is not valid in time
+     */
+    @Override
+    public void validateCertificate(@NonNull X509Certificate x509EeCert, @NonNull ZonedDateTime referenceDate, @NonNull ValidationContext context) throws GemPkiException {
+
+        boolean isValid = isBetween(
+                        referenceDate,
+                        x509EeCert.getNotBefore().toInstant().atZone(ZoneOffset.UTC),
+                        x509EeCert.getNotAfter().toInstant().atZone(ZoneOffset.UTC));
+
+        if (!isValid) {
+            log.debug(
+                    "Das Referenzdatum {} liegt nicht innerhalb des Gültigkeitsbereichs des Zertifikates.",
+                    referenceDate);
+            throw new GemPkiException(productType, ErrorCode.SE_1021_CERTIFICATE_NOT_VALID_TIME);
+        }
+    }
+
+    private boolean isBetween(
+            final ZonedDateTime referenceDate,
+            final ZonedDateTime startDate,
+            final ZonedDateTime endDate) {
+        return referenceDate.isAfter(startDate) && referenceDate.isBefore(endDate);
+    }
+}

--- a/src/test/java/de/gematik/pki/gemlibpki/certificate/CertificateProfileVerificationTest.java
+++ b/src/test/java/de/gematik/pki/gemlibpki/certificate/CertificateProfileVerificationTest.java
@@ -16,316 +16,38 @@
 
 package de.gematik.pki.gemlibpki.certificate;
 
-import static de.gematik.pki.gemlibpki.TestConstants.FILE_NAME_TSL_ECC_DEFAULT;
-import static de.gematik.pki.gemlibpki.TestConstants.INVALID_CERT_TYPE;
-import static de.gematik.pki.gemlibpki.TestConstants.MISSING_CERT_TYPE;
-import static de.gematik.pki.gemlibpki.TestConstants.MISSING_EXT_KEY_USAGE_EE_CERT;
-import static de.gematik.pki.gemlibpki.TestConstants.MISSING_POLICY_ID_CERT;
-import static de.gematik.pki.gemlibpki.TestConstants.VALID_HBA_AUT_ECC;
-import static de.gematik.pki.gemlibpki.TestConstants.VALID_X509_EE_CERT_ALT_CA;
-import static de.gematik.pki.gemlibpki.TestConstants.VALID_X509_EE_CERT_INVALID_KEY_USAGE;
-import static de.gematik.pki.gemlibpki.TestConstants.VALID_X509_EE_CERT_SMCB;
-import static de.gematik.pki.gemlibpki.certificate.CertificateProfile.CERT_PROFILE_ANY;
-import static de.gematik.pki.gemlibpki.certificate.CertificateProfile.CERT_PROFILE_C_HCI_AUT_ECC;
-import static de.gematik.pki.gemlibpki.certificate.CertificateProfile.CERT_PROFILE_C_HCI_AUT_RSA;
-import static de.gematik.pki.gemlibpki.certificate.CertificateProfile.CERT_PROFILE_C_HP_AUT_ECC;
-import static de.gematik.pki.gemlibpki.utils.TestUtils.assertNonNullParameter;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-
-import de.gematik.pki.gemlibpki.error.ErrorCode;
 import de.gematik.pki.gemlibpki.exception.GemPkiException;
-import de.gematik.pki.gemlibpki.exception.GemPkiRuntimeException;
 import de.gematik.pki.gemlibpki.tsl.TslInformationProvider;
 import de.gematik.pki.gemlibpki.tsl.TspInformationProvider;
 import de.gematik.pki.gemlibpki.tsl.TspServiceSubset;
 import de.gematik.pki.gemlibpki.utils.TestUtils;
-import java.io.IOException;
-import java.security.cert.CertificateParsingException;
-import java.security.cert.X509Certificate;
-import lombok.NonNull;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedConstruction;
-import org.mockito.Mockito;
+
+import static de.gematik.pki.gemlibpki.TestConstants.FILE_NAME_TSL_ECC_DEFAULT;
+import static de.gematik.pki.gemlibpki.TestConstants.VALID_X509_EE_CERT_SMCB;
+import static de.gematik.pki.gemlibpki.certificate.CertificateProfile.CERT_PROFILE_C_HCI_AUT_ECC;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class CertificateProfileVerificationTest {
 
-  private String productType;
-  private CertificateProfileVerification certificateProfileVerification;
+    @Test
+    void verifyValid() throws GemPkiException {
 
-  @BeforeEach
-  void setUp() throws GemPkiException {
+        String productType = "IDP";
 
-    productType = "IDP";
-    certificateProfileVerification = buildCertificateProfileVerifier(CERT_PROFILE_C_HCI_AUT_ECC);
-  }
+        final TspServiceSubset tspServiceSubset =
+                new TspInformationProvider(
+                        new TslInformationProvider(TestUtils.getTslUnsigned(FILE_NAME_TSL_ECC_DEFAULT)).getTspServices(),
+                        productType)
+                        .getIssuerTspServiceSubset(VALID_X509_EE_CERT_SMCB);
 
-  private CertificateProfileVerification buildCertificateProfileVerifier(
-      final CertificateProfile certificateProfile) throws GemPkiException {
-    return buildCertificateProfileVerifier(
-        FILE_NAME_TSL_ECC_DEFAULT, certificateProfile, VALID_X509_EE_CERT_SMCB);
-  }
-
-  private CertificateProfileVerification buildCertificateProfileVerifier(
-      @NonNull final String tslFilename,
-      final CertificateProfile certificateProfile,
-      final X509Certificate x509EeCert)
-      throws GemPkiException {
-
-    final TspServiceSubset tspServiceSubset =
-        new TspInformationProvider(
-                new TslInformationProvider(TestUtils.getTslUnsigned(tslFilename)).getTspServices(),
-                productType)
-            .getIssuerTspServiceSubset(x509EeCert);
-
-    return CertificateProfileVerification.builder()
-        .productType(productType)
-        .x509EeCert(x509EeCert)
-        .certificateProfile(certificateProfile)
-        .tspServiceSubset(tspServiceSubset)
-        .build();
-  }
-
-  @Test
-  void verifyCertificateProfileNull() {
-    assertNonNullParameter(
-        () ->
-            buildCertificateProfileVerifier(
-                FILE_NAME_TSL_ECC_DEFAULT, null, VALID_X509_EE_CERT_SMCB),
-        "certificateProfile");
-  }
-
-  @Test
-  void verifyTspProfileNull() {
-    assertNonNullParameter(
-        () ->
-            buildCertificateProfileVerifier(
-                null, CERT_PROFILE_C_HCI_AUT_ECC, VALID_X509_EE_CERT_SMCB),
-        "tslFilename");
-  }
-
-  @Test
-  void verifyKeyUsageValid() {
-    assertDoesNotThrow(() -> certificateProfileVerification.verifyKeyUsage());
-  }
-
-  @Test
-  void verifyKeyUsageMissingInCertificate() throws GemPkiException {
-    final X509Certificate missingKeyUsagex509EeCert =
-        TestUtils.readCert("GEM.SMCB-CA10/invalid/DrMedGunther_missing-keyusage.pem");
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(
-            FILE_NAME_TSL_ECC_DEFAULT, CERT_PROFILE_C_HCI_AUT_ECC, missingKeyUsagex509EeCert);
-    assertThatThrownBy(verifier::verifyKeyUsage)
-        .isInstanceOf(GemPkiException.class)
-        .hasMessage(ErrorCode.SE_1016_WRONG_KEYUSAGE.getErrorMessage(productType));
-  }
-
-  @Test
-  void verifyKeyUsageInvalidInCertificate() throws GemPkiException {
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(
-            FILE_NAME_TSL_ECC_DEFAULT,
-            CERT_PROFILE_C_HCI_AUT_ECC,
-            VALID_X509_EE_CERT_INVALID_KEY_USAGE);
-    assertThatThrownBy(verifier::verifyKeyUsage)
-        .isInstanceOf(GemPkiException.class)
-        .hasMessage(ErrorCode.SE_1016_WRONG_KEYUSAGE.getErrorMessage(productType));
-  }
-
-  @Test
-  void verifyKeyUsageInvalidInCertificateButNotChecked() throws GemPkiException {
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(
-            FILE_NAME_TSL_ECC_DEFAULT, CERT_PROFILE_ANY, VALID_X509_EE_CERT_INVALID_KEY_USAGE);
-    assertDoesNotThrow(verifier::verifyKeyUsage);
-  }
-
-  @Test
-  void verifyNotAllKeyUsagesPresentInCert() throws GemPkiException {
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(CERT_PROFILE_C_HCI_AUT_RSA);
-    assertThatThrownBy(verifier::verifyKeyUsage)
-        .isInstanceOf(GemPkiException.class)
-        .hasMessage(ErrorCode.SE_1016_WRONG_KEYUSAGE.getErrorMessage(productType));
-  }
-
-  @Test
-  void verifyToManyKeyUsagesPresentInCert() throws GemPkiException {
-
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(
-            FILE_NAME_TSL_ECC_DEFAULT, CERT_PROFILE_C_HCI_AUT_ECC, VALID_HBA_AUT_ECC);
-    assertThatThrownBy(verifier::verifyKeyUsage)
-        .isInstanceOf(GemPkiException.class)
-        .hasMessage(ErrorCode.SE_1016_WRONG_KEYUSAGE.getErrorMessage(productType));
-  }
-
-  @Test
-  void verifyExtendedKeyUsageValid() {
-    assertDoesNotThrow(() -> certificateProfileVerification.verifyExtendedKeyUsage());
-  }
-
-  @Test
-  void verifyNotAllExtendedKeyUsagesPresentInCert() throws GemPkiException {
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(CERT_PROFILE_C_HP_AUT_ECC);
-    assertThatThrownBy(verifier::verifyExtendedKeyUsage)
-        .isInstanceOf(GemPkiException.class)
-        .hasMessage(ErrorCode.SE_1017_WRONG_EXTENDEDKEYUSAGE.getErrorMessage(productType));
-  }
-
-  @Test
-  void verifyToManyExtendedKeyUsagesPresentInCert() throws GemPkiException {
-
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(
-            FILE_NAME_TSL_ECC_DEFAULT, CERT_PROFILE_C_HCI_AUT_ECC, VALID_HBA_AUT_ECC);
-    assertThatThrownBy(verifier::verifyExtendedKeyUsage)
-        .isInstanceOf(GemPkiException.class)
-        .hasMessage(ErrorCode.SE_1017_WRONG_EXTENDEDKEYUSAGE.getErrorMessage(productType));
-  }
-
-  @Test
-  void verifyExtendedKeyUsageMissingInCertificate() throws GemPkiException {
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(
-            FILE_NAME_TSL_ECC_DEFAULT, CERT_PROFILE_C_HCI_AUT_ECC, MISSING_EXT_KEY_USAGE_EE_CERT);
-    assertThatThrownBy(verifier::verifyExtendedKeyUsage)
-        .isInstanceOf(GemPkiException.class)
-        .hasMessage(ErrorCode.SE_1017_WRONG_EXTENDEDKEYUSAGE.getErrorMessage(productType));
-  }
-
-  @Test
-  void verifyExtendedKeyUsageMissingInCertificateAndNotExpected() throws GemPkiException {
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(
-            FILE_NAME_TSL_ECC_DEFAULT, CERT_PROFILE_ANY, MISSING_EXT_KEY_USAGE_EE_CERT);
-    assertDoesNotThrow(verifier::verifyExtendedKeyUsage);
-  }
-
-  @Test
-  void verifyExtendedKeyUsageNotChecked() throws GemPkiException {
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(
-            FILE_NAME_TSL_ECC_DEFAULT, CERT_PROFILE_ANY, VALID_X509_EE_CERT_SMCB);
-    assertDoesNotThrow(verifier::verifyExtendedKeyUsage);
-  }
-
-  @Test
-  void verifyExtendedKeyUsageInvalidInCertificate() throws GemPkiException {
-    final X509Certificate invalidExtendedKeyUsageEeCert =
-        TestUtils.readCert("GEM.SMCB-CA10/invalid/DrMedGunther_invalid-ext-keyusage.pem");
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(
-            FILE_NAME_TSL_ECC_DEFAULT, CERT_PROFILE_C_HCI_AUT_ECC, invalidExtendedKeyUsageEeCert);
-    assertThatThrownBy(verifier::verifyExtendedKeyUsage)
-        .isInstanceOf(GemPkiException.class)
-        .hasMessage(ErrorCode.SE_1017_WRONG_EXTENDEDKEYUSAGE.getErrorMessage(productType));
-  }
-
-  @Test
-  void verifyExtendedKeyUsageCertificateParsingException()
-      throws GemPkiException, CertificateParsingException {
-
-    final X509Certificate cert = Mockito.spy(VALID_X509_EE_CERT_SMCB);
-    Mockito.when(cert.getExtendedKeyUsage()).thenThrow(new CertificateParsingException());
-
-    certificateProfileVerification =
-        buildCertificateProfileVerifier(
-            FILE_NAME_TSL_ECC_DEFAULT, CERT_PROFILE_C_HCI_AUT_ECC, cert);
-
-    assertThatThrownBy(certificateProfileVerification::verifyExtendedKeyUsage)
-        .isInstanceOf(GemPkiRuntimeException.class)
-        .hasMessage(
-            "Fehler beim Lesen der ExtendedKeyUsages des Zertifikats: CN=Zahnarztpraxis Dr."
-                + " med.Gunther KZV"
-                + " TEST-ONLY,2.5.4.5=#131731372e3830323736383833313139313130303033333237,O=2-2.30.1.16.TestOnly"
-                + " NOT-VALID,C=DE");
-  }
-
-  @Test
-  void multipleCertificateProfilesMultipleCertTypesInEe() {
-    final X509Certificate eeMultipleCertTypes =
-        TestUtils.readCert("GEM.SMCB-CA9/Aschoffsche_Apotheke_twoCertTypes.pem");
-    assertDoesNotThrow(
-        () ->
-            buildCertificateProfileVerifier(
-                    FILE_NAME_TSL_ECC_DEFAULT, CERT_PROFILE_C_HCI_AUT_ECC, eeMultipleCertTypes)
-                .verifyCertificateType());
-  }
-
-  @Test
-  void verifyCertificateProfileMissingPolicyId() throws GemPkiException {
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(
-            FILE_NAME_TSL_ECC_DEFAULT, CERT_PROFILE_C_HCI_AUT_ECC, MISSING_POLICY_ID_CERT);
-    assertThatThrownBy(verifier::verifyCertificateType)
-        .isInstanceOf(GemPkiException.class)
-        .hasMessage(ErrorCode.SE_1033_CERT_TYPE_INFO_MISSING.getErrorMessage(productType));
-  }
-
-  @Test
-  void verifyCertificateProfileMissingCertType() throws GemPkiException {
-
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(
-            FILE_NAME_TSL_ECC_DEFAULT, CERT_PROFILE_C_HCI_AUT_ECC, MISSING_CERT_TYPE);
-    assertThatThrownBy(verifier::verifyCertificateType)
-        .isInstanceOf(GemPkiException.class)
-        .hasMessage(ErrorCode.SE_1033_CERT_TYPE_INFO_MISSING.getErrorMessage(productType));
-  }
-
-  @Test
-  void verifyCertificateProfileInvalidCertType() throws GemPkiException {
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(
-            FILE_NAME_TSL_ECC_DEFAULT, CERT_PROFILE_C_HCI_AUT_ECC, INVALID_CERT_TYPE);
-    assertThatThrownBy(verifier::verifyCertificateType)
-        .isInstanceOf(GemPkiException.class)
-        .hasMessage(ErrorCode.SE_1018_CERT_TYPE_MISMATCH.getErrorMessage(productType));
-  }
-
-  @Test
-  void verifyCertificateProfileWrongServiceInfoExtInTsl() throws GemPkiException {
-    final String tslAltCaWrongServiceExtension =
-        "tsls/ecc/defect/TSL_defect_altCA_wrong-srvInfoExt.xml";
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(
-            tslAltCaWrongServiceExtension, CERT_PROFILE_C_HCI_AUT_ECC, VALID_X509_EE_CERT_ALT_CA);
-    assertThatThrownBy(verifier::verifyCertificateType)
-        .isInstanceOf(GemPkiException.class)
-        .hasMessage(ErrorCode.SE_1061_CERT_TYPE_CA_NOT_AUTHORIZED.getErrorMessage(productType));
-  }
-
-  @Test
-  void verifyCriticalExtensions() throws GemPkiException {
-    final String certFilename = "GEM.SMCB-CA10/invalid/DrMedGunther_invalid-extension-crit.pem";
-    final X509Certificate certInvalidCriticalExtension = TestUtils.readCert(certFilename);
-
-    final CertificateProfileVerification verifier =
-        buildCertificateProfileVerifier(
-            FILE_NAME_TSL_ECC_DEFAULT, CERT_PROFILE_C_HCI_AUT_ECC, certInvalidCriticalExtension);
-
-    assertThatThrownBy(verifier::verifyCriticalExtensions)
-        .isInstanceOf(GemPkiException.class)
-        .hasMessage(ErrorCode.CUSTOM_CERTIFICATE_EXCEPTION.getErrorMessage(productType));
-  }
-
-  @Test
-  void testGetCertificatePolicyOidsException() {
-
-    try (final MockedConstruction<Policies> ignored =
-        Mockito.mockConstructionWithAnswer(
-            Policies.class,
-            invocation -> {
-              throw new IOException();
-            })) {
-
-      assertThatThrownBy(() -> certificateProfileVerification.verifyCertificateType())
-          .isInstanceOf(GemPkiException.class)
-          .hasMessage(ErrorCode.TE_1019_CERT_READ_ERROR.getErrorMessage(productType));
+        CertificateProfileVerification tested = CertificateProfileVerification.builder()
+                .productType(productType)
+                .x509EeCert(VALID_X509_EE_CERT_SMCB)
+                .certificateProfile(CERT_PROFILE_C_HCI_AUT_ECC)
+                .tspServiceSubset(tspServiceSubset)
+                .build();
+        assertDoesNotThrow(tested::verifyAll);
     }
-  }
+
 }

--- a/src/test/java/de/gematik/pki/gemlibpki/certificate/TucPki018VerifierTest.java
+++ b/src/test/java/de/gematik/pki/gemlibpki/certificate/TucPki018VerifierTest.java
@@ -454,22 +454,23 @@ class TucPki018VerifierTest {
                 VALID_X509_EE_CERT_SMCB, CERT_PROFILE_C_HCI_AUT_ECC, null),
         "tspServiceSubset");
 
-    assertNonNullParameter(
-        () -> tucPki018Verifier.commonChecks(null, tspServiceSubset), "x509EeCert");
-
-    assertNonNullParameter(
-        () -> tucPki018Verifier.commonChecks(VALID_X509_EE_CERT_SMCB, null), "tspServiceSubset");
-
     final ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
-    assertNonNullParameter(
-        () -> tucPki018Verifier.doOcspIfConfigured(null, tspServiceSubset, now), "x509EeCert");
 
     assertNonNullParameter(
-        () -> tucPki018Verifier.doOcspIfConfigured(VALID_X509_EE_CERT_SMCB, null, now),
-        "tspServiceSubset");
+        () -> tucPki018Verifier.commonChecks(null, tspServiceSubset, now), "x509EeCert");
 
     assertNonNullParameter(
-        () -> tucPki018Verifier.doOcspIfConfigured(VALID_X509_EE_CERT_SMCB, tspServiceSubset, null),
+        () -> tucPki018Verifier.commonChecks(VALID_X509_EE_CERT_SMCB, null, now), "tspServiceSubset");
+
+    assertNonNullParameter(
+            () -> tucPki018Verifier.commonChecks(VALID_X509_EE_CERT_SMCB, tspServiceSubset, null), "referenceDate");
+
+    assertNonNullParameter(
+        () -> tucPki018Verifier.doOcspIfConfigured(null, now), "x509EeCert");
+
+
+    assertNonNullParameter(
+        () -> tucPki018Verifier.doOcspIfConfigured(VALID_X509_EE_CERT_SMCB, null),
         "referenceDate");
   }
 
@@ -527,7 +528,7 @@ class TucPki018VerifierTest {
   @Test
   void verifyPerformTucPki18ChecksWithGivenOcspResponseValid() {
 
-    final ZonedDateTime referenceDate = GemLibPkiUtils.now().minusYears(10);
+    final ZonedDateTime referenceDate = ZonedDateTime.parse("2022-06-20T15:00:00Z");
 
     final OCSPReq ocspReq =
         OcspRequestGenerator.generateSingleOcspRequest(

--- a/src/test/java/de/gematik/pki/gemlibpki/validators/CertificateProfileByCertificateTypeOidValidatorTest.java
+++ b/src/test/java/de/gematik/pki/gemlibpki/validators/CertificateProfileByCertificateTypeOidValidatorTest.java
@@ -1,0 +1,84 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.certificate.Policies;
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import de.gematik.pki.gemlibpki.utils.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.security.cert.X509Certificate;
+
+import static de.gematik.pki.gemlibpki.TestConstants.*;
+import static de.gematik.pki.gemlibpki.certificate.CertificateProfile.CERT_PROFILE_C_HCI_AUT_ECC;
+import static de.gematik.pki.gemlibpki.utils.TestUtils.assertNonNullParameter;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class CertificateProfileByCertificateTypeOidValidatorTest {
+
+    @Test
+    void verifyConstructorNullParameter() {
+        assertNonNullParameter(() -> new CertificateProfileByCertificateTypeOidValidator(null), "productType");
+    }
+
+    @Test
+    void verifyValidateCertificateNullParameter() {
+        X509Certificate x509EeCert = Mockito.mock(X509Certificate.class);
+
+        CertificateProfileByCertificateTypeOidValidator tested = new CertificateProfileByCertificateTypeOidValidator(PRODUCT_TYPE);
+
+        assertNonNullParameter(() -> tested.validateCertificate(null, CERT_PROFILE_C_HCI_AUT_ECC), "x509EeCert");
+        assertNonNullParameter(() -> tested.validateCertificate(x509EeCert, null), "certificateProfile");
+    }
+
+
+    @Test
+    void verifyCertificateProfileInvalidCertType() throws GemPkiException {
+
+        assertThatThrownBy(() -> doValidateCertificate(INVALID_CERT_TYPE))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1018_CERT_TYPE_MISMATCH.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void multipleCertificateProfilesMultipleCertTypesInEe() {
+        final X509Certificate eeMultipleCertTypes =
+                TestUtils.readCert("GEM.SMCB-CA9/Aschoffsche_Apotheke_twoCertTypes.pem");
+        assertDoesNotThrow(() -> doValidateCertificate(eeMultipleCertTypes));
+    }
+
+
+    @Test
+    void verifyCertificateProfileMissingPolicyId() {
+        assertThatThrownBy(() -> doValidateCertificate(MISSING_POLICY_ID_CERT))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1033_CERT_TYPE_INFO_MISSING.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void verifyCertificateProfileMissingCertType() {
+
+        assertThatThrownBy(() -> doValidateCertificate(MISSING_CERT_TYPE))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1033_CERT_TYPE_INFO_MISSING.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void testGetCertificatePolicyOidsException() {
+        try (MockedConstruction<Policies> ignored = Mockito.mockConstructionWithAnswer(Policies.class, invocation -> {
+            throw new IOException();
+        })) {
+
+            assertThatThrownBy(() -> doValidateCertificate(VALID_X509_EE_CERT_SMCB))
+                    .isInstanceOf(GemPkiException.class)
+                    .hasMessage(ErrorCode.TE_1019_CERT_READ_ERROR.getErrorMessage(PRODUCT_TYPE));
+        }
+    }
+
+    private void doValidateCertificate(final X509Certificate x509EeCert) throws GemPkiException {
+        new CertificateProfileByCertificateTypeOidValidator(PRODUCT_TYPE).validateCertificate(x509EeCert, CERT_PROFILE_C_HCI_AUT_ECC);
+    }
+}

--- a/src/test/java/de/gematik/pki/gemlibpki/validators/CertificateTypeOidInIssuerTspServiceExtensionValidatorTest.java
+++ b/src/test/java/de/gematik/pki/gemlibpki/validators/CertificateTypeOidInIssuerTspServiceExtensionValidatorTest.java
@@ -1,0 +1,105 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.certificate.Policies;
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import de.gematik.pki.gemlibpki.tsl.TslInformationProvider;
+import de.gematik.pki.gemlibpki.tsl.TspInformationProvider;
+import de.gematik.pki.gemlibpki.tsl.TspServiceSubset;
+import de.gematik.pki.gemlibpki.utils.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.security.cert.X509Certificate;
+
+import static de.gematik.pki.gemlibpki.TestConstants.*;
+import static de.gematik.pki.gemlibpki.certificate.CertificateProfile.CERT_PROFILE_C_HCI_AUT_ECC;
+import static de.gematik.pki.gemlibpki.utils.TestUtils.assertNonNullParameter;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class CertificateTypeOidInIssuerTspServiceExtensionValidatorTest {
+
+    @Test
+    void verifyConstructorNullParameter() {
+        TspServiceSubset tspServiceSubset = Mockito.mock(TspServiceSubset.class);
+
+        assertNonNullParameter(() -> new CertificateTypeOidInIssuerTspServiceExtensionValidator(null, tspServiceSubset), "productType");
+        assertNonNullParameter(() -> new CertificateTypeOidInIssuerTspServiceExtensionValidator(PRODUCT_TYPE, null), "tspServiceSubset");
+    }
+
+    @Test
+    void verifyValidateCertificateNullParameter() {
+        TspServiceSubset tspServiceSubset = Mockito.mock(TspServiceSubset.class);
+        X509Certificate x509EeCert = Mockito.mock(X509Certificate.class);
+
+        CertificateTypeOidInIssuerTspServiceExtensionValidator tested = new CertificateTypeOidInIssuerTspServiceExtensionValidator(PRODUCT_TYPE, tspServiceSubset);
+
+        assertNonNullParameter(() -> tested.validateCertificate(null, CERT_PROFILE_C_HCI_AUT_ECC), "x509EeCert");
+        assertNonNullParameter(() -> tested.validateCertificate(x509EeCert, null), "certificateProfile");
+    }
+
+    @Test
+    void verifyCertificateProfileWrongServiceInfoExtInTsl() {
+        final String tslAltCaWrongServiceExtension = "tsls/ecc/defect/TSL_defect_altCA_wrong-srvInfoExt.xml";
+
+        assertThatThrownBy(() -> doValidateCertificate(tslAltCaWrongServiceExtension, VALID_X509_EE_CERT_ALT_CA))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1061_CERT_TYPE_CA_NOT_AUTHORIZED.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void multipleCertificateProfilesMultipleCertTypesInEe() {
+        final X509Certificate eeMultipleCertTypes =
+                TestUtils.readCert("GEM.SMCB-CA9/Aschoffsche_Apotheke_twoCertTypes.pem");
+        assertDoesNotThrow(() -> doValidateCertificate(eeMultipleCertTypes));
+    }
+
+    @Test
+    void verifyCertificateProfileMissingPolicyId() {
+
+        assertThatThrownBy(() -> doValidateCertificate(MISSING_POLICY_ID_CERT))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1033_CERT_TYPE_INFO_MISSING.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void verifyCertificateProfileMissingCertType() {
+
+        assertThatThrownBy(() -> doValidateCertificate(MISSING_CERT_TYPE))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1033_CERT_TYPE_INFO_MISSING.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void testGetCertificatePolicyOidsException() {
+        X509Certificate validX509EeCert = TestUtils.readCert("GEM.SMCB-CA10/valid/DrMedGunther.pem");
+
+        try (final MockedConstruction<Policies> ignored = Mockito.mockConstructionWithAnswer(Policies.class, invocation -> {
+            throw new IOException();
+        })) {
+
+            assertThatThrownBy(() -> doValidateCertificate(validX509EeCert))
+                    .isInstanceOf(GemPkiException.class)
+                    .hasMessage(ErrorCode.TE_1019_CERT_READ_ERROR.getErrorMessage(PRODUCT_TYPE));
+        }
+    }
+
+    private void doValidateCertificate(final X509Certificate x509EeCert) throws GemPkiException {
+        doValidateCertificate(FILE_NAME_TSL_ECC_DEFAULT, x509EeCert);
+    }
+
+    private void doValidateCertificate(final String tslFilename, final X509Certificate x509EeCert) throws GemPkiException {
+
+        final TspServiceSubset tspServiceSubset =
+                new TspInformationProvider(
+                        new TslInformationProvider(TestUtils.getTslUnsigned(tslFilename)).getTspServices(),
+                        PRODUCT_TYPE)
+                        .getIssuerTspServiceSubset(x509EeCert);
+
+        new CertificateTypeOidInIssuerTspServiceExtensionValidator(PRODUCT_TYPE, tspServiceSubset).validateCertificate(x509EeCert, CERT_PROFILE_C_HCI_AUT_ECC);
+    }
+
+}

--- a/src/test/java/de/gematik/pki/gemlibpki/validators/CriticalExtensionsValidatorTest.java
+++ b/src/test/java/de/gematik/pki/gemlibpki/validators/CriticalExtensionsValidatorTest.java
@@ -1,0 +1,45 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import de.gematik.pki.gemlibpki.utils.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.security.cert.X509Certificate;
+
+import static de.gematik.pki.gemlibpki.TestConstants.PRODUCT_TYPE;
+import static de.gematik.pki.gemlibpki.certificate.CertificateProfile.CERT_PROFILE_C_HCI_AUT_ECC;
+import static de.gematik.pki.gemlibpki.utils.TestUtils.assertNonNullParameter;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CriticalExtensionsValidatorTest {
+
+    @Test
+    void verifyConstructorNullParameter() {
+        assertNonNullParameter(() -> new CriticalExtensionsValidator(null), "productType");
+    }
+
+    @Test
+    void verifyValidateCertificateNullParameter() {
+        X509Certificate x509EeCert = Mockito.mock(X509Certificate.class);
+
+        CriticalExtensionsValidator tested = new CriticalExtensionsValidator(PRODUCT_TYPE);
+
+        assertNonNullParameter(() -> tested.validateCertificate(null, CERT_PROFILE_C_HCI_AUT_ECC), "x509EeCert");
+        assertNonNullParameter(() -> tested.validateCertificate(x509EeCert, null), "certificateProfile");
+    }
+
+
+    @Test
+    void verifyCriticalExtensions() {
+        final X509Certificate certInvalidCriticalExtension = TestUtils.readCert("GEM.SMCB-CA10/invalid/DrMedGunther_invalid-extension-crit.pem");
+
+        CriticalExtensionsValidator tested = new CriticalExtensionsValidator(PRODUCT_TYPE);
+
+        assertThatThrownBy(() -> tested.validateCertificate(certInvalidCriticalExtension, CERT_PROFILE_C_HCI_AUT_ECC))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.CUSTOM_CERTIFICATE_EXCEPTION.getErrorMessage(PRODUCT_TYPE));
+    }
+
+}

--- a/src/test/java/de/gematik/pki/gemlibpki/validators/ExtendedKeyUsageValidatorTest.java
+++ b/src/test/java/de/gematik/pki/gemlibpki/validators/ExtendedKeyUsageValidatorTest.java
@@ -1,0 +1,106 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.certificate.CertificateProfile;
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import de.gematik.pki.gemlibpki.exception.GemPkiRuntimeException;
+import de.gematik.pki.gemlibpki.utils.TestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+
+import static de.gematik.pki.gemlibpki.TestConstants.*;
+import static de.gematik.pki.gemlibpki.certificate.CertificateProfile.*;
+import static de.gematik.pki.gemlibpki.utils.TestUtils.assertNonNullParameter;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class ExtendedKeyUsageValidatorTest {
+
+    private final static CertificateProfile CERTIFICATE_PROFILE = CERT_PROFILE_C_HCI_AUT_ECC;
+
+    private ExtendedKeyUsageValidator tested;
+
+    @BeforeEach
+    void setUp() {
+        tested = new ExtendedKeyUsageValidator(PRODUCT_TYPE);
+    }
+
+    @Test
+    void verifyConstructorNullParameter() {
+        assertNonNullParameter(() -> new ExtendedKeyUsageValidator(null), "productType");
+    }
+
+    @Test
+    void verifyValidateCertificateNullParameter() {
+        assertNonNullParameter(() -> tested.validateCertificate(null, CERTIFICATE_PROFILE), "x509EeCert");
+        assertNonNullParameter(() -> tested.validateCertificate(VALID_X509_EE_CERT_SMCB, null), "certificateProfile");
+    }
+
+    @Test
+    void verifyExtendedKeyUsageMissingInCertificateAndNotExpected() {
+        assertDoesNotThrow(() -> tested.validateCertificate(MISSING_EXT_KEY_USAGE_EE_CERT, CERT_PROFILE_ANY));
+    }
+
+    @Test
+    void verifyExtendedKeyUsageNotChecked() {
+
+        assertDoesNotThrow(() -> tested.validateCertificate(VALID_X509_EE_CERT_SMCB, CERT_PROFILE_ANY));
+    }
+
+    @Test
+    void verifyExtendedKeyUsageValid() {
+        assertDoesNotThrow(() -> tested.validateCertificate(VALID_X509_EE_CERT_SMCB, CERTIFICATE_PROFILE));
+    }
+
+    @Test
+    void verifyNotAllExtendedKeyUsagesPresentInCert() throws GemPkiException {
+
+        assertThatThrownBy(() -> tested.validateCertificate(VALID_X509_EE_CERT_SMCB, CERT_PROFILE_C_HP_AUT_ECC))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1017_WRONG_EXTENDEDKEYUSAGE.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void verifyToManyExtendedKeyUsagesPresentInCert() {
+        assertThatThrownBy(() -> tested.validateCertificate(VALID_HBA_AUT_ECC, CERT_PROFILE_C_HCI_AUT_ECC))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1017_WRONG_EXTENDEDKEYUSAGE.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void verifyExtendedKeyUsageMissingInCertificate() {
+        assertThatThrownBy(() -> tested.validateCertificate(MISSING_EXT_KEY_USAGE_EE_CERT, CERTIFICATE_PROFILE))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1017_WRONG_EXTENDEDKEYUSAGE.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void verifyExtendedKeyUsageInvalidInCertificate() {
+        X509Certificate invalidExtendedKeyUsageEeCert = TestUtils.readCert("GEM.SMCB-CA10/invalid/DrMedGunther_invalid-ext-keyusage.pem");
+
+        assertThatThrownBy(() -> tested.validateCertificate(invalidExtendedKeyUsageEeCert, CERTIFICATE_PROFILE))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1017_WRONG_EXTENDEDKEYUSAGE.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void verifyExtendedKeyUsageCertificateParsingException()
+            throws CertificateParsingException {
+
+        final X509Certificate cert = Mockito.spy(VALID_X509_EE_CERT_SMCB);
+        Mockito.when(cert.getExtendedKeyUsage()).thenThrow(new CertificateParsingException());
+
+        assertThatThrownBy(() -> tested.validateCertificate(cert, CERTIFICATE_PROFILE))
+                .isInstanceOf(GemPkiRuntimeException.class)
+                .hasMessage(
+                        "Fehler beim Lesen der ExtendedKeyUsages des Zertifikats: CN=Zahnarztpraxis Dr."
+                                + " med.Gunther KZV"
+                                + " TEST-ONLY,2.5.4.5=#131731372e3830323736383833313139313130303033333237,O=2-2.30.1.16.TestOnly"
+                                + " NOT-VALID,C=DE");
+    }
+
+}

--- a/src/test/java/de/gematik/pki/gemlibpki/validators/IssuerServiceStatusValidatorTest.java
+++ b/src/test/java/de/gematik/pki/gemlibpki/validators/IssuerServiceStatusValidatorTest.java
@@ -1,0 +1,93 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import de.gematik.pki.gemlibpki.tsl.TslInformationProvider;
+import de.gematik.pki.gemlibpki.tsl.TspInformationProvider;
+import de.gematik.pki.gemlibpki.tsl.TspService;
+import de.gematik.pki.gemlibpki.tsl.TspServiceSubset;
+import de.gematik.pki.gemlibpki.utils.TestUtils;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.security.cert.X509Certificate;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static de.gematik.pki.gemlibpki.TestConstants.*;
+import static de.gematik.pki.gemlibpki.utils.TestUtils.assertNonNullParameter;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class IssuerServiceStatusValidatorTest {
+
+    @Test
+    void verifyConstructorNullParameter() {
+
+        TspServiceSubset tspServiceSubset = Mockito.mock(TspServiceSubset.class);
+
+        assertNonNullParameter(() -> new IssuerServiceStatusValidator(null, tspServiceSubset), "productType");
+        assertNonNullParameter(() -> new IssuerServiceStatusValidator(PRODUCT_TYPE, null), "tspServiceSubset");
+    }
+
+
+    @Test
+    void verifyValidateCertificateNullParameter() {
+        TspServiceSubset tspServiceSubset = Mockito.mock(TspServiceSubset.class);
+        ZonedDateTime zonedDateTime = Mockito.mock(ZonedDateTime.class);
+
+        IssuerServiceStatusValidator tested = new IssuerServiceStatusValidator(PRODUCT_TYPE, tspServiceSubset);
+
+        assertNonNullParameter(() -> tested.validateCertificate(null), "x509EeCert");
+        assertNonNullParameter(() -> tested.validateCertificate(null, zonedDateTime), "x509EeCert");
+        assertNonNullParameter(() -> tested.validateCertificate(null, zonedDateTime, new CertificateValidator.ValidationContext()), "x509EeCert");
+
+
+        assertNonNullParameter(() -> tested.validateCertificate(VALID_X509_EE_CERT_ALT_CA, null), "referenceDate");
+        assertNonNullParameter(() -> tested.validateCertificate(VALID_X509_EE_CERT_ALT_CA, null, new CertificateValidator.ValidationContext()), "referenceDate");
+
+        assertNonNullParameter(() -> tested.validateCertificate(VALID_X509_EE_CERT_ALT_CA, zonedDateTime, null), "context");
+    }
+
+
+    @Test
+    void verifyIssuerServiceStatusNotRevoked() {
+        assertDoesNotThrow(() -> doValidateCertificate(FILE_NAME_TSL_ECC_ALT_CA, VALID_X509_EE_CERT_ALT_CA));
+    }
+
+    /**
+     * Timestamp "notBefore" of VALID_X509_EE_CERT_ALT_CA is before StatusStartingTime of TSPService
+     * (issuer of VALID_X509_EE_CERT_ALT_CA) in TSL FILE_NAME_TSL_ALT_CA_REVOKED
+     */
+    @Test
+    void verifyIssuerServiceStatusRevokedLater() {
+        final String tslAltCaRevokedLater = "tsls/ecc/valid/TSL_altCA_revokedLater.xml";
+        assertDoesNotThrow(() -> doValidateCertificate(tslAltCaRevokedLater, VALID_X509_EE_CERT_ALT_CA));
+    }
+
+    /**
+     * Timestamp "notBefore" of VALID_X509_EE_CERT_ALT_CA is after StatusStartingTime of TSPService
+     * (issuer of VALID_X509_EE_CERT_ALT_CA) in TSL FILE_NAME_TSL_ALT_CA_REVOKED
+     */
+    @Test
+    void verifyIssuerServiceStatusRevoked() {
+
+        assertThatThrownBy(() -> doValidateCertificate("tsls/ecc/valid/TSL_altCA_revoked.xml", VALID_X509_EE_CERT_ALT_CA))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1036_CA_CERTIFICATE_REVOKED_IN_TSL.getErrorMessage(PRODUCT_TYPE));
+    }
+
+
+    private void doValidateCertificate(@NonNull final String tslFilename, final X509Certificate x509EeCert) throws GemPkiException {
+
+        List<TspService> tspServices = new TslInformationProvider(TestUtils.getTslUnsigned(tslFilename)).getTspServices();
+        TspServiceSubset tspServiceSubset = new TspInformationProvider(tspServices, PRODUCT_TYPE).getIssuerTspServiceSubset(x509EeCert);
+
+        IssuerServiceStatusValidator tested = new IssuerServiceStatusValidator(PRODUCT_TYPE, tspServiceSubset);
+
+        tested.validateCertificate(x509EeCert);
+    }
+
+
+}

--- a/src/test/java/de/gematik/pki/gemlibpki/validators/KeyUsageValidatorTest.java
+++ b/src/test/java/de/gematik/pki/gemlibpki/validators/KeyUsageValidatorTest.java
@@ -1,0 +1,82 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.certificate.CertificateProfile;
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import de.gematik.pki.gemlibpki.utils.TestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.cert.X509Certificate;
+
+import static de.gematik.pki.gemlibpki.TestConstants.*;
+import static de.gematik.pki.gemlibpki.certificate.CertificateProfile.*;
+import static de.gematik.pki.gemlibpki.utils.TestUtils.assertNonNullParameter;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class KeyUsageValidatorTest {
+
+    private final static CertificateProfile CERTIFICATE_PROFILE = CERT_PROFILE_C_HCI_AUT_ECC;
+    private final static X509Certificate VALID_X_509_EE_CERT = TestUtils.readCert("GEM.SMCB-CA10/valid/DrMedGunther.pem");
+    private KeyUsageValidator tested;
+
+    @BeforeEach
+    void setUp() {
+        tested = new KeyUsageValidator(PRODUCT_TYPE);
+    }
+
+    @Test
+    void verifyConstructorNullParameter() {
+        assertNonNullParameter(() -> new KeyUsageValidator(null), "productType");
+    }
+
+    @Test
+    void verifyValidateCertificateNullParameter() {
+        assertNonNullParameter(() -> tested.validateCertificate(null, CERTIFICATE_PROFILE), "x509EeCert");
+        assertNonNullParameter(() -> tested.validateCertificate(VALID_X_509_EE_CERT, null), "certificateProfile");
+    }
+
+
+    @Test
+    void verifyKeyUsageValid() {
+        assertDoesNotThrow(() -> tested.validateCertificate(VALID_X_509_EE_CERT, CERTIFICATE_PROFILE));
+    }
+
+    @Test
+    void verifyKeyUsageInvalidInCertificateButNotChecked() {
+        assertDoesNotThrow(() -> tested.validateCertificate(VALID_X509_EE_CERT_INVALID_KEY_USAGE, CERT_PROFILE_ANY));
+    }
+
+    @Test
+    void verifyKeyUsageMissingInCertificate() {
+        X509Certificate missingKeyUsages509EeCert = TestUtils.readCert("GEM.SMCB-CA10/invalid/DrMedGunther_missing-keyusage.pem");
+
+        assertThatThrownBy(() -> tested.validateCertificate(missingKeyUsages509EeCert, CERTIFICATE_PROFILE))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1016_WRONG_KEYUSAGE.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void verifyKeyUsageInvalidInCertificate() {
+
+        assertThatThrownBy(() -> tested.validateCertificate(VALID_X509_EE_CERT_INVALID_KEY_USAGE, CERTIFICATE_PROFILE))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1016_WRONG_KEYUSAGE.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void verifyNotAllKeyUsagesPresentInCert() {
+        assertThatThrownBy(() -> tested.validateCertificate(VALID_X_509_EE_CERT, CERT_PROFILE_C_HCI_AUT_RSA))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1016_WRONG_KEYUSAGE.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void verifyToManyKeyUsagesPresentInCert() {
+        assertThatThrownBy(() -> tested.validateCertificate(VALID_HBA_AUT_ECC, CERT_PROFILE_C_HCI_AUT_ECC))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1016_WRONG_KEYUSAGE.getErrorMessage(PRODUCT_TYPE));
+    }
+
+}

--- a/src/test/java/de/gematik/pki/gemlibpki/validators/SignatureValidatorTest.java
+++ b/src/test/java/de/gematik/pki/gemlibpki/validators/SignatureValidatorTest.java
@@ -1,0 +1,66 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import de.gematik.pki.gemlibpki.utils.TestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.security.cert.X509Certificate;
+import java.time.ZonedDateTime;
+
+import static de.gematik.pki.gemlibpki.TestConstants.*;
+import static de.gematik.pki.gemlibpki.utils.TestUtils.assertNonNullParameter;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class SignatureValidatorTest {
+
+
+    private SignatureValidator tested;
+
+    @BeforeEach
+    void setUp() {
+        tested = new SignatureValidator(PRODUCT_TYPE, VALID_ISSUER_CERT_SMCB);
+    }
+
+
+    @Test
+    void verifyConstructorNullParameter() {
+        assertNonNullParameter(() -> new SignatureValidator(null, VALID_ISSUER_CERT_SMCB), "productType");
+        assertNonNullParameter(() -> new SignatureValidator(PRODUCT_TYPE, null), "x509IssuerCert");
+    }
+
+    @Test
+    void verifyValidateCertificateNullParameter() {
+        ZonedDateTime zonedDateTime = Mockito.mock(ZonedDateTime.class);
+
+        assertNonNullParameter(() -> tested.validateCertificate(null), "x509EeCert");
+        assertNonNullParameter(() -> tested.validateCertificate(null, zonedDateTime), "x509EeCert");
+        assertNonNullParameter(() -> tested.validateCertificate(null, zonedDateTime, new CertificateValidator.ValidationContext()), "x509EeCert");
+
+
+        assertNonNullParameter(() -> tested.validateCertificate(VALID_X509_EE_CERT_SMCB, null), "referenceDate");
+        assertNonNullParameter(() -> tested.validateCertificate(VALID_X509_EE_CERT_SMCB, null, new CertificateValidator.ValidationContext()), "referenceDate");
+
+        assertNonNullParameter(() -> tested.validateCertificate(VALID_X509_EE_CERT_SMCB, zonedDateTime, null), "context");
+    }
+
+
+    @Test
+    void verifySignatureValid() {
+        assertDoesNotThrow(() -> tested.validateCertificate(VALID_X509_EE_CERT_SMCB));
+    }
+
+    @Test
+    void verifySignatureNotValid() throws GemPkiException {
+        final X509Certificate invalidX509EeCert = TestUtils.readCert("GEM.SMCB-CA10/invalid/DrMedGunther_invalid-signature.pem");
+
+        assertThatThrownBy(() -> tested.validateCertificate(invalidX509EeCert))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1024_CERTIFICATE_NOT_VALID_MATH.getErrorMessage(PRODUCT_TYPE));
+    }
+
+
+}

--- a/src/test/java/de/gematik/pki/gemlibpki/validators/ValidityValidatorTest.java
+++ b/src/test/java/de/gematik/pki/gemlibpki/validators/ValidityValidatorTest.java
@@ -1,0 +1,71 @@
+package de.gematik.pki.gemlibpki.validators;
+
+import de.gematik.pki.gemlibpki.error.ErrorCode;
+import de.gematik.pki.gemlibpki.exception.GemPkiException;
+import de.gematik.pki.gemlibpki.utils.TestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.cert.X509Certificate;
+import java.time.ZonedDateTime;
+
+import static de.gematik.pki.gemlibpki.TestConstants.PRODUCT_TYPE;
+import static de.gematik.pki.gemlibpki.utils.TestUtils.assertNonNullParameter;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class ValidityValidatorTest {
+
+    private static final X509Certificate VALID_X509_EE_CERT = TestUtils.readCert("GEM.SMCB-CA10/valid/DrMedGunther.pem");
+    private static final ZonedDateTime ZONED_DATE_TIME = ZonedDateTime.parse("2020-11-20T15:00:00Z");
+    private ValidityValidator tested;
+
+    @BeforeEach
+    void setUp() {
+        tested = new ValidityValidator(PRODUCT_TYPE);
+    }
+
+    @Test
+    void verifyConstructorNullParameter() {
+        assertNonNullParameter(() -> new ValidityValidator(null), "productType");
+    }
+
+    @Test
+    void verifyValidateCertificateNullParameter() {
+
+        assertNonNullParameter(() -> tested.validateCertificate(null), "x509EeCert");
+        assertNonNullParameter(() -> tested.validateCertificate(null, ZONED_DATE_TIME), "x509EeCert");
+        assertNonNullParameter(() -> tested.validateCertificate(null, ZONED_DATE_TIME, new CertificateValidator.ValidationContext()), "x509EeCert");
+
+
+        assertNonNullParameter(() -> tested.validateCertificate(VALID_X509_EE_CERT, null), "referenceDate");
+        assertNonNullParameter(() -> tested.validateCertificate(VALID_X509_EE_CERT, null, new CertificateValidator.ValidationContext()), "referenceDate");
+
+        assertNonNullParameter(() -> tested.validateCertificate(VALID_X509_EE_CERT, ZONED_DATE_TIME, null), "context");
+    }
+
+
+    @Test
+    void verifyValidityCertificateExpired() {
+        X509Certificate expiredEeCert = TestUtils.readCert("GEM.SMCB-CA10/invalid/DrMedGunther_expired.pem");
+
+        assertThatThrownBy(() -> tested.validateCertificate(expiredEeCert, ZONED_DATE_TIME))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1021_CERTIFICATE_NOT_VALID_TIME.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void verifyValidityCertificateNotYetValid() {
+        X509Certificate notYetValidEeCert = TestUtils.readCert("GEM.SMCB-CA10/invalid/DrMedGunther_not-yet-valid.pem");
+
+        assertThatThrownBy(() -> tested.validateCertificate(notYetValidEeCert, ZONED_DATE_TIME))
+                .isInstanceOf(GemPkiException.class)
+                .hasMessage(ErrorCode.SE_1021_CERTIFICATE_NOT_VALID_TIME.getErrorMessage(PRODUCT_TYPE));
+    }
+
+    @Test
+    void verifyValidityCertificateValid() {
+        assertDoesNotThrow(() -> tested.validateCertificate(VALID_X509_EE_CERT, ZONED_DATE_TIME));
+    }
+
+}


### PR DESCRIPTION
Introduce validation interface to encapsulate validation steps. This approach/desgin is more API like and allows to reuse validation steps in other certificate validation chains (e.g. TUC_PKI_030)

Note, the business code was mainly copy&pastes as it is - from validation-step-method to validation-step-interface.